### PR TITLE
Refactoring...

### DIFF
--- a/UmbracoUdiToIdCache.Tests/UdiToIdCacheTests.cs
+++ b/UmbracoUdiToIdCache.Tests/UdiToIdCacheTests.cs
@@ -1,14 +1,14 @@
-﻿namespace UmbracoUdiToIdCache.Tests
-{
-    using System;
-    using FluentAssertions;
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using Moq;
-    using Umbraco.Core;
-    using Umbraco.Core.Models;
+﻿using System;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Our.Umbraco.UdiCache;
+using Umbraco.Core.Models;
 
+namespace UmbracoUdiToIdCache.Tests
+{
     [TestClass]
-    public class UdiToIdCacheTests
+    public class GuidToIdCacheTests
     {
         protected IContent MockContent(int id, Guid key)
         {
@@ -19,19 +19,19 @@
         }
 
         [TestClass]
-        public class TheAddToCacheMethod : UdiToIdCacheTests
+        public class TheTryAddMethod : GuidToIdCacheTests
         {
             [TestMethod]
             public void ShouldAddKeyValuePairIfDoesNotAlreadyExist()
             {
                 // Arrange
-                UdiToIdCache.Clear();
+                GuidToIdCache.ClearAll();
                 var key = Guid.NewGuid();
                 var content = MockContent(1001, key);
-                UdiToIdCache.AddToCache(content);
+                GuidToIdCache.TryAdd(content);
 
                 // Act
-                var result = UdiToIdCache.TryGetId(content.GetUdi(), out int id);
+                var result = GuidToIdCache.TryGetId(content.Key, out int id);
 
                 // Assert
                 result.Should().BeTrue();
@@ -42,14 +42,14 @@
             public void ShouldRetainKeyValuePairIfAlreadyExists()
             {
                 // Arrange
-                UdiToIdCache.Clear();
+                GuidToIdCache.ClearAll();
                 var key = Guid.NewGuid();
                 var content = MockContent(1001, key);
-                UdiToIdCache.AddToCache(content);
-                UdiToIdCache.AddToCache(content);
+                GuidToIdCache.TryAdd(content);
+                GuidToIdCache.TryAdd(content);
 
                 // Act
-                var result = UdiToIdCache.TryGetId(content.GetUdi(), out int id);
+                var result = GuidToIdCache.TryGetId(content.Key, out int id);
 
                 // Assert
                 result.Should().BeTrue();
@@ -58,19 +58,19 @@
         }
 
         [TestClass]
-        public class TheTryGetIdMethod : UdiToIdCacheTests
+        public class TheTryGetIdMethod : GuidToIdCacheTests
         {
             [TestMethod]
             public void ShouldRetrieveIdIfMappingExists()
             {
                 // Arrange
-                UdiToIdCache.Clear();
+                GuidToIdCache.ClearAll();
                 var key = Guid.NewGuid();
                 var content = MockContent(1001, key);
-                UdiToIdCache.AddToCache(content);
+                GuidToIdCache.TryAdd(content);
 
                 // Act
-                var result = UdiToIdCache.TryGetId(content.GetUdi(), out int id);
+                var result = GuidToIdCache.TryGetId(content.Key, out int id);
 
                 // Assert
                 result.Should().BeTrue();
@@ -81,16 +81,93 @@
             public void ShouldNotRetrieveIdIfMappingDoesNotExist()
             {
                 // Arrange
-                UdiToIdCache.Clear();
+                GuidToIdCache.ClearAll();
                 var key = Guid.NewGuid();
                 var content = MockContent(1001, key);
 
                 // Act
-                var result = UdiToIdCache.TryGetId(content.GetUdi(), out int id);
+                var result = GuidToIdCache.TryGetId(content.Key, out int id);
 
                 // Assert
                 result.Should().BeFalse();
                 id.Should().Be(0);
+            }
+        }
+
+        [TestClass]
+        public class TheTryGetGuidMethod : GuidToIdCacheTests
+        {
+            [TestMethod]
+            public void ShouldRetrieveGuidIfMappingExists()
+            {
+                // Arrange
+                GuidToIdCache.ClearAll();
+                var key = Guid.NewGuid();
+                var content = MockContent(1001, key);
+                GuidToIdCache.TryAdd(content);
+
+                // Act
+                var result = GuidToIdCache.TryGetGuid(content.Id, out Guid guid);
+
+                // Assert
+                result.Should().BeTrue();
+                guid.Should().Be(key);
+            }
+
+            [TestMethod]
+            public void ShouldNotRetrieveGuidIfMappingDoesNotExist()
+            {
+                // Arrange
+                GuidToIdCache.ClearAll();
+                var key = Guid.NewGuid();
+                var content = MockContent(1001, key);
+
+                // Act
+                var result = GuidToIdCache.TryGetGuid(content.Id, out Guid guid);
+
+                // Assert
+                result.Should().BeFalse();
+                guid.Should().Be(Guid.Empty);
+            }
+        }
+
+        [TestClass]
+        public class TheTryRemoveMethod : GuidToIdCacheTests
+        {
+            [TestMethod]
+            public void ShouldRemoveKeyValuePairAndNotRetrieveId()
+            {
+                // Arrange
+                GuidToIdCache.ClearAll();
+                var key = Guid.NewGuid();
+                var content = MockContent(1001, key);
+                GuidToIdCache.TryAdd(content);
+
+                // Act
+                GuidToIdCache.TryRemove(content);
+                var result = GuidToIdCache.TryGetId(content.Key, out int id);
+
+                // Assert
+                result.Should().BeFalse();
+                id.Should().Be(0);
+            }
+
+            [TestMethod]
+            public void ShouldRemoveKeyValuePairAndNotRetrieveGuid()
+            {
+                // Arrange
+                GuidToIdCache.ClearAll();
+                var key = Guid.NewGuid();
+                var content = MockContent(1001, key);
+                GuidToIdCache.TryAdd(content);
+
+                // Act
+                GuidToIdCache.TryRemove(content);
+                var result = GuidToIdCache.TryGetGuid(content.Id, out Guid guid);
+
+                // Assert
+                result.Should().BeFalse();
+                guid.Should().Be(Guid.Empty);
             }
         }
     }

--- a/UmbracoUdiToIdCache.sln
+++ b/UmbracoUdiToIdCache.sln
@@ -1,11 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27004.2005
+VisualStudioVersion = 15.0.27004.2009
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UmbracoUdiToIdCache", "UmbracoUdiToIdCache\UmbracoUdiToIdCache.csproj", "{F6D224E5-0480-4A80-B993-6F1CE5809C28}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestWebApp", "TestWebApp\TestWebApp.csproj", "{AA4FC9C2-E85C-4EA8-998A-EC7A99DF4D33}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UmbracoUdiToIdCache.Tests", "UmbracoUdiToIdCache.Tests\UmbracoUdiToIdCache.Tests.csproj", "{F072C54A-0EB6-480B-A275-ECCEA812140B}"
 EndProject
@@ -19,10 +17,6 @@ Global
 		{F6D224E5-0480-4A80-B993-6F1CE5809C28}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F6D224E5-0480-4A80-B993-6F1CE5809C28}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F6D224E5-0480-4A80-B993-6F1CE5809C28}.Release|Any CPU.Build.0 = Release|Any CPU
-		{AA4FC9C2-E85C-4EA8-998A-EC7A99DF4D33}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{AA4FC9C2-E85C-4EA8-998A-EC7A99DF4D33}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{AA4FC9C2-E85C-4EA8-998A-EC7A99DF4D33}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{AA4FC9C2-E85C-4EA8-998A-EC7A99DF4D33}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F072C54A-0EB6-480B-A275-ECCEA812140B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F072C54A-0EB6-480B-A275-ECCEA812140B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F072C54A-0EB6-480B-A275-ECCEA812140B}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/UmbracoUdiToIdCache/UmbracoHelperExtensions.cs
+++ b/UmbracoUdiToIdCache/UmbracoHelperExtensions.cs
@@ -1,24 +1,37 @@
-﻿namespace Umbraco.Web
-{
-    using Umbraco.Core;
-    using Umbraco.Core.Models;
-    using Umbraco.Web;
-    using UmbracoUdiToIdCache;
+﻿using System;
+using Our.Umbraco.UdiCache;
+using Umbraco.Core;
+using Umbraco.Core.Models;
 
+namespace Umbraco.Web
+{
     public static class UmbracoHelperExtensions
     {
         /// <summary>
-        /// Adds an extension to <see cref="UmbracoHelper"/> to make a call to TypedContent for a Udi
-        /// via a look-up to get the numeric Id
+        /// Gets a content item from the cache.
         /// </summary>
-        /// <param name="helper">Umbraco helper</param>
-        /// <param name="udi">Udi of content node</param>
-        /// <returns>Instance of <see cref="IPublishedContent"/></returns>
-        public static IPublishedContent TypedContentUsingUdiToIdCache(this UmbracoHelper helper, Udi udi)
+        /// <param name="helper">The instance of <see cref="UmbracoHelper"/> to add extension method.</param>
+        /// <param name="udi">The <see cref="Udi"/> of the content item.</param>
+        /// <returns>The content, or null of the content item is not in the cache.</returns>
+        public static IPublishedContent TypedContent(this UmbracoHelper helper, Udi udi, bool usingUdiToIdCache)
         {
-            return UdiToIdCache.TryGetId(udi, out int id) 
-                ? helper.TypedContent(id) 
+            return usingUdiToIdCache && udi is GuidUdi guidUdi && GuidToIdCache.TryGetId(guidUdi.Guid, out int id)
+                ? helper.TypedContent(id)
                 : helper.TypedContent(udi);
+        }
+
+        /// <summary>
+        /// Gets a content item from the cache.
+        /// </summary>
+        /// <param name="helper">The instance of <see cref="UmbracoHelper"/> to add extension method.</param>
+        /// <param name="guid">The key of the content item.</param>
+        /// <param name="usingUdiToIdCache"></param>
+        /// <returns>The content, or null of the content item is not in the cache.</returns>
+        public static IPublishedContent TypedContent(this UmbracoHelper helper, Guid guid, bool usingUdiToIdCache)
+        {
+            return usingUdiToIdCache && GuidToIdCache.TryGetId(guid, out int id)
+                ? helper.TypedContent(id)
+                : helper.TypedContent(guid);
         }
     }
 }


### PR DESCRIPTION
Hi @AndyButland - I don't really know why I've done this, guess I had an itch to scratch.

I was curious about reducing the cache size and keeping only published `Udi`s in there.
Then I spotted a couple of potential improvements, one with the SQL query, another with the cache-refreshers, and then I got a bit carried away. 😨 

Here are the changes I made...

- Changed namespace to "Our.Umbraco" prefix - makes for less VS intellisense pollution
- Changed `AppEvents` to inherit from `ApplicationEventHandler` - less code
- Changed the Published event to use the cache-refresher events - future-proofing for load-balancing
- Added cache-refresher for page unpublished event - to remove from the cache lookup
- Changed the cache key type from `Udi` to `Guid` - as it gives it more scope
- Added bi-directional lookup for the cache, so that items can be removed by either GUID or ID
- Renamed extension method, adding parameter (to say use cache lookup)
- Updated unit-tests

I have no expectations of you merging this in, like I say I had an itch to scratch.
I'm happy to discuss any bits if you want.